### PR TITLE
BALANCE SCORES

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_quality_score (0.1.10)
+    code_quality_score (1.0.0)
       flay (>= 2.13.0)
       flog (>= 4.6.5)
       reek (>= 6.1.1)
@@ -77,6 +77,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-21
 
 DEPENDENCIES
   code_quality_score!

--- a/lib/code_quality_score/score_snapshot.rb
+++ b/lib/code_quality_score/score_snapshot.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pry-byebug'
 
 module CodeQualityScore
   class ScoreSnapshot
@@ -11,7 +12,7 @@ module CodeQualityScore
       file_count = count_files(folders)
 
       result = {
-        similarity_score_per_file: structural_similarity_score_per_file(folders, file_count),
+        similarity_score_per_file: structural_similarity_score_per_file(folders),
         abc_method_average: abc_method_average_score(folders),
         code_smells_per_file: code_smells_per_file(folders, file_count)
       }
@@ -33,10 +34,11 @@ module CodeQualityScore
       Integer(`find #{folders} -type f | wc -l`)
     end
 
-    def structural_similarity_score_per_file(folders, file_count)
+    def structural_similarity_score_per_file(folders)
       score_line = `flay #{folders}/* | head -n 1`
       score_number = Float(score_line.split(" ").last)
-      (score_number / file_count).round(2)
+      leveler_number = 1000 # to make sure it doesn't swamp other scores
+      (score_number / leveler_number).round(2)
     end
 
     def abc_method_average_score(folders)

--- a/lib/code_quality_score/score_snapshot.rb
+++ b/lib/code_quality_score/score_snapshot.rb
@@ -4,7 +4,7 @@ require 'pry-byebug'
 module CodeQualityScore
   class ScoreSnapshot
     DEFAULT_SCORE_WEIGHTS = {
-      similarity_score: 0.003,
+      similarity_score: 0.01,
       abc_method_average: 0.8,
       code_smells_per_file: 5
     }.freeze

--- a/lib/code_quality_score/score_snapshot.rb
+++ b/lib/code_quality_score/score_snapshot.rb
@@ -3,9 +3,11 @@ require 'pry-byebug'
 
 module CodeQualityScore
   class ScoreSnapshot
-    def initialize(repository_path:, similarity_score_leveler: 1000)
+    DEFAULT_SCORE_WEIGHTS = { similarity_score: 1, abc_method_average: 1, code_smells_per_file: 1 }.freeze
+
+    def initialize(repository_path:, score_weights: {})
       @repo_path = repository_path
-      @similarity_score_leveler = similarity_score_leveler
+      @score_weights = DEFAULT_SCORE_WEIGHTS.merge(score_weights)
     end
 
     def calculate_score
@@ -13,9 +15,9 @@ module CodeQualityScore
       file_count = count_files(folders)
 
       result = {
-        similarity_score: structural_similarity_score_per_file(folders),
+        similarity_score: structural_similarity_score(folders),
         abc_method_average: abc_method_average_score(folders),
-        code_smells_per_file: code_smells_per_file(folders, file_count),
+        code_smells_per_file: code_smells_per_file(folders, file_count)
       }
 
       result[:total_score] = result.values.sum.round(2)
@@ -36,21 +38,26 @@ module CodeQualityScore
       Integer(`find #{folders} -type f | wc -l`)
     end
 
-    def structural_similarity_score_per_file(folders)
+    def structural_similarity_score(folders)
       score_line = `flay #{folders}/* | head -n 1`
-      score_number = Float(score_line.split(" ").last)
-      (score_number / @similarity_score_leveler).round(2)
+      score_number = Float(score_line.split(" ").last).round(2)
+      weighted_score = score_number * @score_weights[:similarity_score]
+      weighted_score.round(2)
     end
 
     def abc_method_average_score(folders)
       score_line = `flog #{folders}/* | head -n 2 | tail -1`
-      Float(score_line.split(":").first)
+      score = Float(score_line.split(":").first).round(2)
+      weighted_score = score * @score_weights[:abc_method_average]
+      weighted_score.round(2)
     end
 
     def code_smells_per_file(folders, file_count)
       score_line = `reek #{folders}/* | tail -1`
       score_number = Float(score_line.split(" ").first)
-      (score_number / file_count).round(2)
+      score_per_file = (score_number / file_count).round(2)
+      weighted_score = score_per_file * @score_weights[:code_smells_per_file]
+      weighted_score.round(2)
     end
   end
 end

--- a/lib/code_quality_score/score_snapshot.rb
+++ b/lib/code_quality_score/score_snapshot.rb
@@ -4,7 +4,7 @@ require 'pry-byebug'
 module CodeQualityScore
   class ScoreSnapshot
     DEFAULT_SCORE_WEIGHTS = {
-      similarity_score: 0.01,
+      similarity_score: 0.003,
       abc_method_average: 0.8,
       code_smells_per_file: 5
     }.freeze

--- a/spec/code_quality_score_spec.rb
+++ b/spec/code_quality_score_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CodeQualityScore::ScoreSnapshot do
       code_smells_per_file: 0.5,
       similarity_score: 44.0,
       total_file_count: 2,
+      ruby_file_count: 2,
       total_score: 53.0
     }
   end

--- a/spec/code_quality_score_spec.rb
+++ b/spec/code_quality_score_spec.rb
@@ -3,19 +3,43 @@
 require "code_quality_score/score_snapshot"
 
 RSpec.describe CodeQualityScore::ScoreSnapshot do
-  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./", similarity_score_leveler: 1000) }
+  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./spec/test_project") }
+  let(:expected_scores) do
+    {
+      abc_method_average: 8.5,
+      code_smells_per_file: 0.5,
+      similarity_score: 44.0,
+      total_file_count: 2,
+      total_score: 53.0
+    }
+  end
 
   it "has a version number" do
     expect(CodeQualityScore::VERSION).not_to be nil
   end
 
-  it "calculates scores for it's own code without error" do
-    expect(score_snapshot.calculate_score).to eq({
-                                                   abc_method_average: 6.0,
-                                                   code_smells_per_file: 0.5,
-                                                   similarity_score: 0.0,
-                                                   total_file_count: 4,
-                                                   total_score: 6.5
-                                                 })
+  it "calculates scores for a repository as expected" do
+    expect(score_snapshot.calculate_score).to eq(expected_scores)
+  end
+
+  context "when custom score weights are passed" do
+    subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./spec/test_project", score_weights: score_weights) }
+    let(:score_weights) do
+      {
+        similarity_score: 0.001,
+        abc_method_average: 3,
+        code_smells_per_file: 10
+      }
+    end
+
+    it "multiplies the scores by the new weights" do
+      result = score_snapshot.calculate_score
+
+      [:similarity_score, :abc_method_average, :code_smells_per_file].each do |score_type|
+        actual = result[score_type]
+        expected = (expected_scores[score_type] * score_weights[score_type]).round(2)
+        expect(actual).to eq(expected)
+      end
+    end
   end
 end

--- a/spec/code_quality_score_spec.rb
+++ b/spec/code_quality_score_spec.rb
@@ -3,7 +3,7 @@
 require "code_quality_score/score_snapshot"
 
 RSpec.describe CodeQualityScore::ScoreSnapshot do
-  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./") }
+  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./", similarity_score_leveler: 1000) }
 
   it "has a version number" do
     expect(CodeQualityScore::VERSION).not_to be nil
@@ -11,10 +11,11 @@ RSpec.describe CodeQualityScore::ScoreSnapshot do
 
   it "calculates scores for it's own code without error" do
     expect(score_snapshot.calculate_score).to eq({
-                                                   abc_method_average: 5.9,
-                                                   code_smells_per_file: 0.25,
-                                                   similarity_score_per_file: 0.0,
-                                                   total_score: 6.15
+                                                   abc_method_average: 6.0,
+                                                   code_smells_per_file: 0.5,
+                                                   similarity_score: 0.0,
+                                                   total_file_count: 4,
+                                                   total_score: 6.5
                                                  })
   end
 end

--- a/spec/code_quality_score_spec.rb
+++ b/spec/code_quality_score_spec.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
-require "code_quality_score/score_snapshotter"
+require "code_quality_score/score_snapshot"
 
-RSpec.describe CodeQualityScore do
+RSpec.describe CodeQualityScore::ScoreSnapshot do
+  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./") }
+
   it "has a version number" do
     expect(CodeQualityScore::VERSION).not_to be nil
   end
 
-  it "calculates scores" do
-    expect(CodeQualityScore::ScoreSnapshotter.calculate_score_snapshot(true)).to eq({
-                                                                                      abc_method_average: 6.8,
-                                                                                      code_smells_per_file: 0.5,
-                                                                                      similarity_score_per_file: 14.5,
-                                                                                      total_score: 21.8
-                                                                                    })
+  it "calculates scores for it's own code without error" do
+    expect(score_snapshot.calculate_score).to eq({
+                                                   abc_method_average: 5.9,
+                                                   code_smells_per_file: 0.25,
+                                                   similarity_score_per_file: 0.0,
+                                                   total_score: 6.15
+                                                 })
   end
 end

--- a/spec/code_quality_score_spec.rb
+++ b/spec/code_quality_score_spec.rb
@@ -3,7 +3,14 @@
 require "code_quality_score/score_snapshot"
 
 RSpec.describe CodeQualityScore::ScoreSnapshot do
-  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./spec/test_project") }
+  subject(:score_snapshot) { CodeQualityScore::ScoreSnapshot.new(repository_path: "./spec/test_project", score_weights: score_weights) }
+  let(:score_weights) do
+    {
+      similarity_score: 1,
+      abc_method_average: 1,
+      code_smells_per_file: 1
+    }
+  end
   let(:expected_scores) do
     {
       abc_method_average: 8.5,

--- a/spec/test_project/app/foo.rb
+++ b/spec/test_project/app/foo.rb
@@ -1,0 +1,28 @@
+class Foo
+  def initialize(repository_path:, score_weights: {})
+    @repo_path = repository_path
+    @score_weights = score_weights
+  end
+
+  def structural_similarity_score_per_file(folders)
+    score_line = `flay #{folders}/* | head -n 1`
+    score_number = Float(score_line.split(" ").last)
+    weighted_score = score_number * @score_weights[:similarity]
+    weighted_score.round(2)
+  end
+
+  def abc_method_average_score(folders)
+    score_line = `flog #{folders}/* | head -n 2 | tail -1`
+    score = Float(score_line.split(":").first)
+    weighted_score = score * @score_weights[:abc_method]
+    weighted_score.round(2)
+  end
+
+  def code_smells_per_file(folders, file_count)
+    score_line = `reek #{folders}/* | tail -1`
+    score_number = Float(score_line.split(" ").first)
+    score_per_file = score_number / file_count
+    weighted_score = score_per_file * @score_weights[:code_smells]
+    weighted_score.round(2)
+  end
+end

--- a/spec/test_project/lib/bar.rb
+++ b/spec/test_project/lib/bar.rb
@@ -1,0 +1,32 @@
+class Bar
+  def self.format_as_markdown(base_result, pr_result)
+    difference_result = base_result.map do |key, value|
+      difference_value = (pr_result[key] - value).round(2)
+      [key, difference_value]
+    end.to_h
+
+    total_score_difference = difference_result[:total_score]
+
+    intro_summary = if total_score_difference.negative?
+                      "improved"
+                    elsif total_score_difference.zero?
+                      "not changed"
+                    else
+                      "got worse"
+                    end
+
+    result = <<~HEREDOC
+      ## Code quality score
+      The code quality has #{intro_summary} for this PR.
+
+      |         | Similarity score | ABC complexity | Code smells | TOTALS |
+      |---------|------------------|----------------|-------------|--------|
+      #{format_row("base", base_result)}
+      #{format_row("this branch", pr_result)}
+      #{format_row("difference", difference_result)}
+
+    HEREDOC
+
+    puts result
+  end
+end


### PR DESCRIPTION
- Similarity score is no longer divided by files
- Code smells is now divided by ruby files, not all files
- Adjusted weights so each component of score is roughly between 0-10 (excluding outliers)
- Exposing total files count and ruby file count
- Fixed unit tests so maintainable