### PR TITLE
fix: removing import of pry-byebug because when installed as gem, it …

### DIFF
--- a/lib/code_quality_score/score_snapshot.rb
+++ b/lib/code_quality_score/score_snapshot.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry-byebug'
 
 module CodeQualityScore
   class ScoreSnapshot


### PR DESCRIPTION
…isn't a dependency