### PR TITLE
Added ruby_parser to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/code_quality_score.gemspec
+++ b/code_quality_score.gemspec
@@ -25,10 +25,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
+  spec.add_dependency "faraday", ">= 2.9.0"
   spec.add_dependency "flay", ">= 2.13.0"
   spec.add_dependency "flog", ">= 4.6.5"
   spec.add_dependency "reek", ">= 6.1.1"
-  spec.add_dependency "faraday", ">= 2.9.0"
+  spec.add_dependency "ruby_parser"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
We added ruby_parser because code_quality_score uses it for structural similarity analysis but doesn't declare it as a dependency. Without it, parsing fails and causes a TypeError: can't convert nil into Float in structural_similarity_score.